### PR TITLE
Add ".github/workflows/publish.yml workflow"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: publish
+on:
+  push: 
+    branches: [ main ] 
+  workflow_dispatch:
+
+env: 
+  BACKEND_IMAGE: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/sfc-backend
+  FRONTEND_IMAGE: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/sfc-frontend
+  SHORT_SHA: ${{ github.sha }} 
+
+jobs: 
+  build-and-push: 
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout 
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+
+      - name: Build and push backend 
+        uses: docker/build-push-action@v6
+        with: 
+          context: ./backend
+          push: true 
+          tags: |
+            ${{ env.BACKEND_IMAGE }}:latest
+            ${{ env.BACKEND_IMAGE}}:${{ env.SHORT_SHA }}
+      
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with: 
+          context: ./frontend
+          push: true
+          tags: |
+            ${{ env.FRONTEND_IMAGE }}:latest
+            ${{ env.FRONTEND_IMAGE}}:${{ env.SHORT_SHA }}


### PR DESCRIPTION
Add .github/workflows/publish.yml workflow to CI/CD

- Created new workflow file: .github/workflows/publish.yml
- Workflow runs on push to main and via manual trigger (workflow_dispatch)
- Sets environment variables for backend/frontend Docker images and commit SHA
- Builds and pushes Docker images for both backend and frontend to Docker Hub
- Includes login to Docker Hub and tagging of images with both 'latest' and short SHA